### PR TITLE
fix: do not require bakeware argc

### DIFF
--- a/bakeware/lib/bakeware/script.ex
+++ b/bakeware/lib/bakeware/script.ex
@@ -32,37 +32,58 @@ defmodule Bakeware.Script do
 
       @doc false
       def _main() do
-        {argc, ""} = Integer.parse(System.get_env("BAKEWARE_ARGC"))
-
-        args =
-          if argc > 0 do
-            for v <- 1..argc, do: System.get_env("BAKEWARE_ARG#{v}")
-          else
-            []
-          end
-
-        main(args)
-        |> result_to_halt()
+        (&main/1)
+        |> Bakeware.Script._main()
         |> :erlang.halt()
-      catch
-        error, reason ->
-          IO.warn(
-            "Caught exception in main/1: #{inspect(error)} => #{inspect(reason, pretty: true)}",
-            __STACKTRACE__
-          )
-
-          :erlang.halt(1)
       end
-
-      defp result_to_halt(:ok), do: 0
-      defp result_to_halt(:error), do: 1
-      defp result_to_halt(:abort), do: :abort
-      defp result_to_halt(status) when is_integer(status) and status >= 0, do: status
-      defp result_to_halt(status) when is_list(status), do: status
-      defp result_to_halt(status) when is_binary(status), do: to_charlist(status)
-
-      defp result_to_halt(unknown),
-        do: raise("Invalid return value from #{__MODULE__}.main/1: #{inspect(unknown)}")
     end
   end
+
+  @doc false
+  @spec _main(main_fn :: fun()) :: no_return
+  def _main(main_fn) do
+    argc = get_argc!()
+
+    args =
+      if argc > 0 do
+        for v <- 1..argc, do: System.get_env("BAKEWARE_ARG#{v}")
+      else
+        []
+      end
+
+    args
+    |> main_fn.()
+    |> result_to_halt()
+  catch
+    error, reason ->
+      IO.warn(
+        "Caught exception in main/1: #{inspect(error)} => #{inspect(reason, pretty: true)}",
+        __STACKTRACE__
+      )
+
+      :erlang.halt(1)
+  end
+
+  defp get_argc! do
+    "BAKEWARE_ARGC"
+    |> System.get_env("0")
+    |> Integer.parse()
+    |> case do
+      {argc, ""} ->
+        argc
+
+      _ ->
+        raise("Invalid BAKEWARE_ARGC environment variable set.")
+    end
+  end
+
+  defp result_to_halt(:ok), do: 0
+  defp result_to_halt(:error), do: 1
+  defp result_to_halt(:abort), do: :abort
+  defp result_to_halt(status) when is_integer(status) and status >= 0, do: status
+  defp result_to_halt(status) when is_list(status), do: status
+  defp result_to_halt(status) when is_binary(status), do: to_charlist(status)
+
+  defp result_to_halt(unknown),
+    do: raise("Invalid return value from #{__MODULE__}.main/1: #{inspect(unknown)}")
 end

--- a/bakeware/test/bakeware/script_test.exs
+++ b/bakeware/test/bakeware/script_test.exs
@@ -1,0 +1,29 @@
+defmodule Bakeware.ScriptTest do
+  use ExUnit.Case, async: false
+
+  alias Bakeware.Script
+
+  describe "_main/1" do
+    test "Should not require BAKEWARE_ARGC" do
+      assert 0 == Script._main(fn _ -> :ok end)
+    end
+
+    test "Should return the expected halt status for each main_fn result" do
+      status_int = :random.uniform(10)
+
+      Enum.each(
+        [
+          {:ok, 0},
+          {:error, 1},
+          {:abort, :abort},
+          {status_int, status_int},
+          {[status_int, status_int], [status_int, status_int]},
+          {"asdf", 'asdf'}
+        ],
+        fn {result, status} ->
+          assert status == Script._main(fn _ -> result end)
+        end
+      )
+    end
+  end
+end

--- a/bakeware/test/bakeware_test.exs
+++ b/bakeware/test/bakeware_test.exs
@@ -1,8 +1,4 @@
 defmodule BakewareTest do
   use ExUnit.Case
   doctest Bakeware
-
-  test "greets the world" do
-    assert Bakeware.hello() == :world
-  end
 end


### PR DESCRIPTION
I ran into some problems when trying to run `iex -S mix` if the main app was a `Bakeware.Script`.
Regardless of the usage, this PR aims to give a more informative error if the variable is set incorrectly.

I also took the opportunity to reduce the size of the macro. This made it easier to unit test the module.