### PR TITLE
Remove `runtime: false` from SimpleScript mix.exs

### DIFF
--- a/examples/simple_script/mix.exs
+++ b/examples/simple_script/mix.exs
@@ -26,7 +26,7 @@ defmodule SimpleScript.MixProject do
   # Run "mix help deps" to learn about dependencies.
   defp deps do
     [
-      {:bakeware, path: "../..", runtime: false}
+      {:bakeware, path: "../.."}
     ]
   end
 


### PR DESCRIPTION
A Bakeware script needs to access the `Bakeware.Script._main/1` function in order to work properly, so the runtime: false option has the effect of not generating the module which needs to be used.

The simple fix is to remove the option.