### PR TITLE
v0.1.1 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## v0.1.1
+
+Initial release to hex.
+
+This release is ok for experimentation, but it not intended for production use.
+It has known issues with script and extraction cache handling.

--- a/mix.exs
+++ b/mix.exs
@@ -1,7 +1,7 @@
 defmodule Bakeware.MixProject do
   use Mix.Project
 
-  @version "0.1.0"
+  @version "0.1.1"
   @source_url "https://github.com/bake-bake-bake/bakeware"
 
   def project do
@@ -51,6 +51,7 @@ defmodule Bakeware.MixProject do
         "mix.exs",
         "Makefile",
         "README.md",
+        "CHANGELOG.md",
         "src/*.[ch]"
       ],
       licenses: ["Apache-2.0"],


### PR DESCRIPTION
The intention of this release is to start using hex.pm for code distribution. My hope is that since people are posting articles about using Bakeware that they can reference the releases instead of our `main` branch. 