### PR TITLE
Fix requirement on argc

### DIFF
--- a/lib/bakeware/script.ex
+++ b/lib/bakeware/script.ex
@@ -19,6 +19,8 @@ defmodule Bakeware.Script do
   defmacro __using__(_opts) do
     quote location: :keep do
       @behaviour Bakeware.Script
+      import Bakeware.Script, only: [get_argc!: 0, get_args: 1, result_to_halt: 1]
+
       use Application
 
       def start(_type, _args) do
@@ -32,37 +34,70 @@ defmodule Bakeware.Script do
 
       @doc false
       def _main() do
-        {argc, ""} = Integer.parse(System.get_env("BAKEWARE_ARGC"))
-
-        args =
-          if argc > 0 do
-            for v <- 1..argc, do: System.get_env("BAKEWARE_ARG#{v}")
-          else
-            []
-          end
-
-        main(args)
+        get_argc!()
+        |> get_args()
+        |> main()
         |> result_to_halt()
         |> :erlang.halt()
       catch
         error, reason ->
           IO.warn(
-            "Caught exception in main/1: #{inspect(error)} => #{inspect(reason, pretty: true)}",
+            "Caught exception in #{__MODULE__}.main/1: #{inspect(error)} => #{
+              inspect(reason, pretty: true)
+            }",
             __STACKTRACE__
           )
 
           :erlang.halt(1)
       end
+    end
+  end
 
-      defp result_to_halt(:ok), do: 0
-      defp result_to_halt(:error), do: 1
-      defp result_to_halt(:abort), do: :abort
-      defp result_to_halt(status) when is_integer(status) and status >= 0, do: status
-      defp result_to_halt(status) when is_list(status), do: status
-      defp result_to_halt(status) when is_binary(status), do: to_charlist(status)
+  defmacro get_argc!() do
+    quote location: :keep do
+      argc_str = System.get_env("BAKEWARE_ARGC", "0")
 
-      defp result_to_halt(unknown),
-        do: raise("Invalid return value from #{__MODULE__}.main/1: #{inspect(unknown)}")
+      case Integer.parse(argc_str) do
+        {argc, ""} -> argc
+        _ -> raise "Invalid BAKEWARE_ARGC - #{argc_str}"
+      end
+    end
+  end
+
+  defmacro get_args(argc) do
+    quote location: :keep, bind_quoted: [argc: argc] do
+      if argc > 0 do
+        for v <- 1..argc, do: System.get_env("BAKEWARE_ARG#{v}")
+      else
+        []
+      end
+    end
+  end
+
+  defmacro result_to_halt(result) do
+    quote location: :keep, bind_quoted: [result: result] do
+      case result do
+        :ok ->
+          0
+
+        :error ->
+          1
+
+        :abort ->
+          :abort
+
+        status when is_integer(status) and status >= 0 ->
+          status
+
+        status when is_list(status) ->
+          status
+
+        status when is_binary(status) ->
+          to_charlist(status)
+
+        unknown ->
+          raise("Invalid return value from #{__MODULE__}.main/1: #{inspect(unknown)}")
+      end
     end
   end
 end

--- a/test/bakeware_script_test.exs
+++ b/test/bakeware_script_test.exs
@@ -1,0 +1,42 @@
+defmodule Bakeware.ScriptTest do
+  use ExUnit.Case, async: true
+
+  require Bakeware.Script
+  alias Bakeware.Script
+
+  test "get_argc!/0" do
+    System.delete_env("BAKEWARE_ARGC")
+    assert 0 == Script.get_argc!()
+  end
+
+  test "get_args/1" do
+    envs = [
+      "There's a",
+      "snake",
+      "in my",
+      "boot!"
+    ]
+
+    for {v, i} <- Enum.with_index(envs, 1), do: System.put_env("BAKEWARE_ARG#{i}", v)
+
+    assert envs == Script.get_args(length(envs))
+  end
+
+  test "result_to_halt/1" do
+    status_int = :random.uniform(10)
+
+    Enum.each(
+      [
+        {:ok, 0},
+        {:error, 1},
+        {:abort, :abort},
+        {status_int, status_int},
+        {[status_int, status_int], [status_int, status_int]},
+        {"asdf", 'asdf'}
+      ],
+      fn {result, status} ->
+        assert status == Script.result_to_halt(result)
+      end
+    )
+  end
+end


### PR DESCRIPTION
This was initially done in f0eb507ee142f45b08533a57744c516aa529d5b4 by @polvalente but introduced an unforseen bug.

Building on their example, this again removes the requirement for argc for the desired behavior of being able to run changes locally for testing.

It also follows the pattern to reduce the amount of code in the __using__ macro for scripts and allows easier unit testing