### PR TITLE
Move launcher code out of priv

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ calling_from_make:
 	mix compile
 endif
 
-PREFIX = $(MIX_APP_PATH)/priv
+PREFIX = $(MIX_APP_PATH)/launcher
 BUILD  = $(MIX_APP_PATH)/obj
 
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -26,7 +26,7 @@ defmodule Bakeware.Assembler do
       assembler
       | path: bake_path,
         cpio: Path.join(bake_path, "#{tmp_name}.cpio"),
-        launcher: Path.join(:code.priv_dir(:bakeware), "launcher"),
+        launcher: Application.app_dir(:bakeware, ["launcher", "launcher"]),
         output: Path.join(bake_path, "#{assembler.name}"),
         trailer: Path.join(bake_path, "#{tmp_name}.trailer")
     }


### PR DESCRIPTION
Even though we're telling people to set `runtime: false` when they
depend on `:bakeware`, it's easy to forget. If you forget, then the
launcher code is included twice - once in the right place and again
inside of the OTP release. By moving the launcher code outside of the
`priv` directory, it no longer gets included in the release for
`runtime: true`.

This also lets us experiment with including runtime code in Bakeware
without bloating the generated binaries as much. For reference, here are
the current release contents for `runtime: true`:

```
bakeware-0.1.1
└── ebin
    ├── bakeware.app
    ├── Elixir.Bakeware.Assembler.beam
    ├── Elixir.Bakeware.beam
    ├── Elixir.Bakeware.Script.beam
    └── Elixir.Mix.Tasks.Bakeware.Assemble.beam
```