### PR TITLE
Add "quiet: true" to reduce build output

### DIFF
--- a/examples/iex_prompt/mix.exs
+++ b/examples/iex_prompt/mix.exs
@@ -34,6 +34,7 @@ defmodule IExPrompt.MixProject do
     [
       overwrite: true,
       cookie: "#{@app}_cookie",
+      quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
       strip_beams: Mix.env() == :prod
     ]

--- a/examples/nif_script/mix.exs
+++ b/examples/nif_script/mix.exs
@@ -36,6 +36,7 @@ defmodule NifScript.MixProject do
     [
       overwrite: true,
       cookie: "#{@app}_cookie",
+      quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
       strip_beams: Mix.env() == :prod
     ]

--- a/examples/phoenix_app/mix.exs
+++ b/examples/phoenix_app/mix.exs
@@ -67,6 +67,7 @@ defmodule PhoenixApp.MixProject do
     [
       overwrite: true,
       cookie: "#{@app}_cookie",
+      quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
       strip_beams: Mix.env() == :prod
     ]

--- a/examples/scenic_app/mix.exs
+++ b/examples/scenic_app/mix.exs
@@ -36,6 +36,7 @@ defmodule ScenicApp.MixProject do
     [
       overwrite: true,
       cookie: "#{@app}_cookie",
+      quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
       strip_beams: Mix.env() == :prod
     ]

--- a/examples/simple_app/mix.exs
+++ b/examples/simple_app/mix.exs
@@ -34,6 +34,7 @@ defmodule SimpleApp.MixProject do
     [
       overwrite: true,
       cookie: "#{@app}_cookie",
+      quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
       strip_beams: Mix.env() == :prod
     ]

--- a/examples/simple_script/mix.exs
+++ b/examples/simple_script/mix.exs
@@ -34,6 +34,7 @@ defmodule SimpleScript.MixProject do
     [
       overwrite: true,
       cookie: "#{@app}_cookie",
+      quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
       strip_beams: Mix.env() == :prod
     ]


### PR DESCRIPTION
Here's an example of what it looked like before:

```
Generated iex_prompt app
* assembling iex_prompt-0.1.0 on MIX_ENV=prod
* skipping runtime configuration (config/runtime.exs not found)
* assembling bakeware iex_prompt

Bakeware successfully assembled executable at:

    _build/prod/rel/bakeware/iex_prompt

Release created at _build/prod/rel/iex_prompt!

    # To start your system
    _build/prod/rel/iex_prompt/bin/iex_prompt start

Once the release is running:

    # To connect to it remotely
    _build/prod/rel/iex_prompt/bin/iex_prompt remote

    # To stop it gracefully (you may also send SIGINT/SIGTERM)
    _build/prod/rel/iex_prompt/bin/iex_prompt stop

To list all commands:

    _build/prod/rel/iex_prompt/bin/iex_prompt
```

After:

```
Generated iex_prompt app
* skipping runtime configuration (config/runtime.exs not found)
* assembling bakeware iex_prompt

Bakeware successfully assembled executable at:

    _build/prod/rel/bakeware/iex_prompt
```