### PR TITLE
Add Erlang distribution docs and disable on most examples

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,18 @@ do:
 5. Make sure that compile-time dependencies are marked as `runtime: false` in
    your `mix.exs` so that they're not included
 
+### Erlang distribution
+
+Bakeware uses [Mix releases](https://hexdocs.pm/mix/Mix.Tasks.Release.html) and
+inherits the default of starting of Erlang distribution. If you're using
+Bakeware for commandline or other short-lived applications, this unnecessarily
+starts Erlang distribution servers running and prevents two application
+instances from running at a time.
+
+To disable, run `mix release.init` to create starter `env.sh.eex` and
+`env.bat.eex` files in the `rel` directory. Then edit the files to set
+`RELEASE_DISTRIBUTION=none`.
+
 ### Creating cross-platform binaries
 
 Bakeware binaries include the Erlang runtime but there are still dependencies on

--- a/examples/iex_prompt/rel/env.bat.eex
+++ b/examples/iex_prompt/rel/env.bat.eex
@@ -1,0 +1,3 @@
+@echo off
+rem Disable Erlang distribution
+set RELEASE_DISTRIBUTION=none

--- a/examples/iex_prompt/rel/env.sh.eex
+++ b/examples/iex_prompt/rel/env.sh.eex
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Disable Erlang distribution
+export RELEASE_DISTRIBUTION=none

--- a/examples/iex_prompt/rel/vm.args.eex
+++ b/examples/iex_prompt/rel/vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, and others)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10

--- a/examples/nif_script/rel/env.bat.eex
+++ b/examples/nif_script/rel/env.bat.eex
@@ -1,0 +1,3 @@
+@echo off
+rem Disable Erlang distribution
+set RELEASE_DISTRIBUTION=none

--- a/examples/nif_script/rel/env.sh.eex
+++ b/examples/nif_script/rel/env.sh.eex
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Disable Erlang distribution
+export RELEASE_DISTRIBUTION=none

--- a/examples/nif_script/rel/vm.args.eex
+++ b/examples/nif_script/rel/vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, and others)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10

--- a/examples/scenic_app/rel/env.bat.eex
+++ b/examples/scenic_app/rel/env.bat.eex
@@ -1,0 +1,3 @@
+@echo off
+rem Disable Erlang distribution
+set RELEASE_DISTRIBUTION=none

--- a/examples/scenic_app/rel/env.sh.eex
+++ b/examples/scenic_app/rel/env.sh.eex
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Disable Erlang distribution
+export RELEASE_DISTRIBUTION=none

--- a/examples/scenic_app/rel/vm.args.eex
+++ b/examples/scenic_app/rel/vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, and others)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10

--- a/examples/simple_app/rel/env.bat.eex
+++ b/examples/simple_app/rel/env.bat.eex
@@ -1,0 +1,3 @@
+@echo off
+rem Disable Erlang distribution
+set RELEASE_DISTRIBUTION=none

--- a/examples/simple_app/rel/env.sh.eex
+++ b/examples/simple_app/rel/env.sh.eex
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Disable Erlang distribution
+export RELEASE_DISTRIBUTION=none

--- a/examples/simple_app/rel/vm.args.eex
+++ b/examples/simple_app/rel/vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, and others)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10

--- a/examples/simple_script/rel/env.bat.eex
+++ b/examples/simple_script/rel/env.bat.eex
@@ -1,0 +1,3 @@
+@echo off
+rem Disable Erlang distribution
+set RELEASE_DISTRIBUTION=none

--- a/examples/simple_script/rel/env.sh.eex
+++ b/examples/simple_script/rel/env.sh.eex
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Disable Erlang distribution
+export RELEASE_DISTRIBUTION=none

--- a/examples/simple_script/rel/vm.args.eex
+++ b/examples/simple_script/rel/vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, and others)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10


### PR DESCRIPTION
Short-lived applications probably don't want Erlang distribution enabled
by default. In addition to adding some startup time (hard to notice in
my testing), it also prevents multiple instances of Bakeware apps from
running. Here's the error that you get:

```
$ _build/prod/rel/bakeware/iex_prompt
Protocol 'inet_tcp': the name iex_prompt@sprint seems to be in use by another Erlang node
```

This commit turns off Erlang distribution in everything except for the
Phoenix app. It also adds a note to the `README.md` about it.