### PR TITLE
Move _GNU_SOURCE definition to Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,6 +22,7 @@ PREFIX = $(MIX_APP_PATH)/launcher
 BUILD  = $(MIX_APP_PATH)/obj
 
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
+CFLAGS += -D_GNU_SOURCE
 LDFLAGS ?=
 
 BAKEWARE_OBJECTS = $(BUILD)/utils.o \

--- a/src/cache.c
+++ b/src/cache.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include "bakeware.h"
 
 #include <errno.h>

--- a/src/utils.c
+++ b/src/utils.c
@@ -1,5 +1,3 @@
-#define _GNU_SOURCE
-
 #include "bakeware.h"
 #include <errno.h>
 #include <stdarg.h>


### PR DESCRIPTION
_GNU_SOURCE is needed for asprintf(3). Rather than define it at the top
of every C file that needs it, this moves it to one place in the
Makefile.