### PR TITLE
Switch cache directory naming to SHA-1 and verify

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,9 @@ BAKEWARE_OBJECTS = $(BUILD)/utils.o \
 	$(BUILD)/trailer.o \
 	$(BUILD)/cpio.o \
 	$(BUILD)/unzstd.o \
-	$(BUILD)/cache.o
+	$(BUILD)/cache.o \
+	$(BUILD)/sha1.o \
+
 
 ZSTD_OBJECTS = $(BUILD)/zstd/lib/decompress/huf_decompress.o \
 	$(BUILD)/zstd/lib/decompress/zstd_ddict.o \

--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ BAKEWARE_OBJECTS = $(BUILD)/utils.o \
 	$(BUILD)/unzstd.o \
 	$(BUILD)/cache.o \
 	$(BUILD)/sha1.o \
-
+	$(BUILD)/sha_read.o
 
 ZSTD_OBJECTS = $(BUILD)/zstd/lib/decompress/huf_decompress.o \
 	$(BUILD)/zstd/lib/decompress/zstd_ddict.o \

--- a/README.md
+++ b/README.md
@@ -204,7 +204,7 @@ Offset from end | Field           | Type           | Description
 -8              | Flags           | 16-bit integer | Set to 0 (no flags yet)
 -12             | Contents offset | 32-bit integer | Offset of CPIO archive
 -16             | Contents length | 32-bit integer | Length of CPIO archive
--48             | SHA256          | 32 bytes       | SHA-256 of the CPIO archive
+-48             | SHA1            | 20 bytes       | SHA-1 of the CPIO archive
 
 ## Cache directory
 
@@ -221,15 +221,11 @@ Here's the layout of each cache entry:
 
 Path                                | Created by | Description
  ---------------------------------- | ---------- | --------------------------
-`$CACHE_DIR/$SHA256/source_paths`   | Launcher   | A list of source paths (used for GC)
-`$CACHE_DIR/$SHA256/bin`            | CPIO       | OTP release's `bin` directory
-`$CACHE_DIR/$SHA256/erts-x.y.z`     | CPIO       | OTP release's ERTS
-`$CACHE_DIR/$SHA256/lib`            | CPIO       | OTP release's `lib` directory
-`$CACHE_DIR/$SHA256/releases`       | CPIO       | OTP release's `releases` directory
-`$CACHE_DIR/$SHA256/start`          | CPIO       | Start script. E.g., `bin/my_otp_release start`
-
-TODO: Add lock file to protect an executable being extracted on top of itself.
-This might actually work, though...
+`$CACHE_DIR/$SHA1/bin`              | CPIO       | OTP release's `bin` directory
+`$CACHE_DIR/$SHA1/erts-x.y.z`       | CPIO       | OTP release's ERTS
+`$CACHE_DIR/$SHA1/lib`              | CPIO       | OTP release's `lib` directory
+`$CACHE_DIR/$SHA1/releases`         | CPIO       | OTP release's `releases` directory
+`$CACHE_DIR/$SHA1/start`            | CPIO       | Start script. E.g., `bin/my_otp_release start`
 
 ## LICENSE
 

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -70,7 +70,8 @@ defmodule Bakeware.Assembler do
 
   defp build_trailer(assembler) do
     # maybe stream here to be more efficient
-    hash = :crypto.hash(:sha256, File.read!(assembler.cpio))
+    hash = :crypto.hash(:sha, File.read!(assembler.cpio))
+    hash_padding = :binary.copy(<<0>>, 12)
     offset = File.stat!(assembler.launcher).size
     cpio_size = File.stat!(assembler.cpio).size
 
@@ -79,8 +80,8 @@ defmodule Bakeware.Assembler do
     flags = 0
 
     trailer_bin =
-      <<hash::binary, cpio_size::32, offset::32, flags::16, compression::8, trailer_version::8,
-        "BAKE">>
+      <<hash::20-bytes, hash_padding::12-bytes, cpio_size::32, offset::32, flags::16,
+        compression::8, trailer_version::8, "BAKE">>
 
     File.write!(assembler.trailer, trailer_bin)
     assembler

--- a/src/bakeware.h
+++ b/src/bakeware.h
@@ -43,8 +43,8 @@ struct bakeware_trailer
     off_t contents_offset;
     size_t contents_length;
 
-    uint8_t sha256[32];
-    char sha256_ascii[65];
+    uint8_t sha1[20];
+    char sha1_ascii[40];
 };
 
 #define BAKEWARE_COMPRESSION_NONE 0

--- a/src/bakeware.h
+++ b/src/bakeware.h
@@ -61,6 +61,11 @@ void unzstd_init(size_t max_bytes);
 void unzstd_free();
 ssize_t unzstd_read(int fd, void *buf, size_t count);
 
+// sha_read
+void sha_init();
+ssize_t sha_read(int fd, void *buf, size_t nbytes);
+void sha_result(uint8_t *digest);
+
 // Cache management
 
 struct bakeware; // FIXME

--- a/src/cache.c
+++ b/src/cache.c
@@ -9,7 +9,7 @@
 
 void cache_init(struct bakeware *bw)
 {
-    snprintf(bw->cache_dir_app, sizeof(bw->cache_dir_app), "%s/%s", bw->cache_dir_base, bw->trailer.sha256_ascii);
+    snprintf(bw->cache_dir_app, sizeof(bw->cache_dir_app), "%s/%s", bw->cache_dir_base, bw->trailer.sha1_ascii);
 }
 
 static void trim_line(char *line)
@@ -22,7 +22,7 @@ static void trim_line(char *line)
 static FILE *fopen_in_cache_dir(const struct bakeware *bw, const char *relpath, const char *modes)
 {
     char *path;
-    if (asprintf(&path, "%s/%s/%s", bw->cache_dir_base, bw->trailer.sha256_ascii, relpath) < 0)
+    if (asprintf(&path, "%s/%s/%s", bw->cache_dir_base, bw->trailer.sha1_ascii, relpath) < 0)
         bw_fatal("asprintf");
     FILE *fp = fopen(path, modes);
     free(path);
@@ -136,7 +136,7 @@ int cache_validate(struct bakeware *bw)
 
 int cache_read_app_data(struct bakeware *bw)
 {
-    snprintf(bw->app_path, sizeof(bw->app_path), "%s/%s/start", bw->cache_dir_base, bw->trailer.sha256_ascii);
+    snprintf(bw->app_path, sizeof(bw->app_path), "%s/%s/start", bw->cache_dir_base, bw->trailer.sha1_ascii);
 
     return 0;
 }

--- a/src/main.c
+++ b/src/main.c
@@ -63,7 +63,7 @@ static void print_trailer_info(const struct bakeware_trailer *trailer)
     printf("Flags: 0x%04x\n", trailer->flags);
     printf("Contents offset: %d\n", (int) trailer->contents_offset);
     printf("Contents length: %d\n", (int) trailer->contents_length);
-    printf("SHA256: %s\n", trailer->sha256_ascii);
+    printf("SHA-1: %s\n", trailer->sha1_ascii);
 }
 
 // Initialize app state

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -1,0 +1,276 @@
+
+/* from valgrind tests */
+
+/* ================ sha1.c ================ */
+/*
+SHA-1 in C
+By Steve Reid <steve@edmweb.com>
+100% Public Domain
+
+Test Vectors (from FIPS PUB 180-1)
+"abc"
+  A9993E36 4706816A BA3E2571 7850C26C 9CD0D89D
+"abcdbcdecdefdefgefghfghighijhijkijkljklmklmnlmnomnopnopq"
+  84983E44 1C3BD26E BAAE4AA1 F95129E5 E54670F1
+A million repetitions of "a"
+  34AA973C D4C4DAA4 F61EEB2B DBAD2731 6534016F
+*/
+
+/* #define LITTLE_ENDIAN * This should be #define'd already, if true. */
+/* #define SHA1HANDSOFF * Copies data before messing with it. */
+
+#define SHA1HANDSOFF
+
+#include <stdio.h>
+#include <string.h>
+#include <sys/types.h>	/* for u_int*_t */
+#if defined(__sun)
+#include "solarisfixes.h"
+#endif
+#include "sha1.h"
+
+#ifndef BYTE_ORDER
+#if (BSD >= 199103)
+# include <machine/endian.h>
+#else
+#if defined(linux) || defined(__linux__)
+# include <endian.h>
+#else
+#define	LITTLE_ENDIAN	1234	/* least-significant byte first (vax, pc) */
+#define	BIG_ENDIAN	4321	/* most-significant byte first (IBM, net) */
+#define	PDP_ENDIAN	3412	/* LSB first in word, MSW first in long (pdp)*/
+
+#if defined(vax) || defined(ns32000) || defined(sun386) || defined(__i386__) || \
+    defined(MIPSEL) || defined(_MIPSEL) || defined(BIT_ZERO_ON_RIGHT) || \
+    defined(__alpha__) || defined(__alpha)
+#define BYTE_ORDER	LITTLE_ENDIAN
+#endif
+
+#if defined(sel) || defined(pyr) || defined(mc68000) || defined(sparc) || \
+    defined(is68k) || defined(tahoe) || defined(ibm032) || defined(ibm370) || \
+    defined(MIPSEB) || defined(_MIPSEB) || defined(_IBMR2) || defined(DGUX) ||\
+    defined(apollo) || defined(__convex__) || defined(_CRAY) || \
+    defined(__hppa) || defined(__hp9000) || \
+    defined(__hp9000s300) || defined(__hp9000s700) || \
+    defined (BIT_ZERO_ON_LEFT) || defined(m68k) || defined(__sparc)
+#define BYTE_ORDER	BIG_ENDIAN
+#endif
+#endif /* linux */
+#endif /* BSD */
+#endif /* BYTE_ORDER */
+
+#if defined(__BYTE_ORDER) && !defined(BYTE_ORDER)
+#if (__BYTE_ORDER == __LITTLE_ENDIAN)
+#define BYTE_ORDER LITTLE_ENDIAN
+#else
+#define BYTE_ORDER BIG_ENDIAN
+#endif
+#endif
+
+#if !defined(BYTE_ORDER) || \
+    (BYTE_ORDER != BIG_ENDIAN && BYTE_ORDER != LITTLE_ENDIAN && \
+    BYTE_ORDER != PDP_ENDIAN)
+	/* you must determine what the correct bit order is for
+	 * your compiler - the next line is an intentional error
+	 * which will force your compiles to bomb until you fix
+	 * the above macros.
+	 */
+#error "Undefined or invalid BYTE_ORDER"
+#endif
+
+#define rol(value, bits) (((value) << (bits)) | ((value) >> (32 - (bits))))
+
+/* blk0() and blk() perform the initial expand. */
+/* I got the idea of expanding during the round function from SSLeay */
+#if BYTE_ORDER == LITTLE_ENDIAN
+#define blk0(i) (block->l[i] = (rol(block->l[i],24)&0xFF00FF00) \
+    |(rol(block->l[i],8)&0x00FF00FF))
+#elif BYTE_ORDER == BIG_ENDIAN
+#define blk0(i) block->l[i]
+#else
+#error "Endianness not defined!"
+#endif
+#define blk(i) (block->l[i&15] = rol(block->l[(i+13)&15]^block->l[(i+8)&15] \
+    ^block->l[(i+2)&15]^block->l[i&15],1))
+
+/* (R0+R1), R2, R3, R4 are the different operations used in SHA1 */
+#define R0(v,w,x,y,z,i) z+=((w&(x^y))^y)+blk0(i)+0x5A827999+rol(v,5);w=rol(w,30);
+#define R1(v,w,x,y,z,i) z+=((w&(x^y))^y)+blk(i)+0x5A827999+rol(v,5);w=rol(w,30);
+#define R2(v,w,x,y,z,i) z+=(w^x^y)+blk(i)+0x6ED9EBA1+rol(v,5);w=rol(w,30);
+#define R3(v,w,x,y,z,i) z+=(((w|x)&y)|(w&x))+blk(i)+0x8F1BBCDC+rol(v,5);w=rol(w,30);
+#define R4(v,w,x,y,z,i) z+=(w^x^y)+blk(i)+0xCA62C1D6+rol(v,5);w=rol(w,30);
+
+
+/* Hash a single 512-bit block. This is the core of the algorithm. */
+
+static void SHA1Transform(uint32_t state[5], const uint8_t buffer[64])
+{
+uint32_t a, b, c, d, e;
+typedef union {
+    uint8_t c[64];
+    uint32_t l[16];
+} CHAR64LONG16;
+#ifdef SHA1HANDSOFF
+CHAR64LONG16 block[1];  /* use array to appear as a pointer */
+    memcpy(block, buffer, 64);
+#else
+    /* The following had better never be used because it causes the
+     * pointer-to-const buffer to be cast into a pointer to non-const.
+     * And the result is written through.  I threw a "const" in, hoping
+     * this will cause a diagnostic.
+     */
+CHAR64LONG16* block = (const CHAR64LONG16*)buffer;
+#endif
+    /* Copy context->state[] to working vars */
+    a = state[0];
+    b = state[1];
+    c = state[2];
+    d = state[3];
+    e = state[4];
+    /* 4 rounds of 20 operations each. Loop unrolled. */
+    R0(a,b,c,d,e, 0); R0(e,a,b,c,d, 1); R0(d,e,a,b,c, 2); R0(c,d,e,a,b, 3);
+    R0(b,c,d,e,a, 4); R0(a,b,c,d,e, 5); R0(e,a,b,c,d, 6); R0(d,e,a,b,c, 7);
+    R0(c,d,e,a,b, 8); R0(b,c,d,e,a, 9); R0(a,b,c,d,e,10); R0(e,a,b,c,d,11);
+    R0(d,e,a,b,c,12); R0(c,d,e,a,b,13); R0(b,c,d,e,a,14); R0(a,b,c,d,e,15);
+    R1(e,a,b,c,d,16); R1(d,e,a,b,c,17); R1(c,d,e,a,b,18); R1(b,c,d,e,a,19);
+    R2(a,b,c,d,e,20); R2(e,a,b,c,d,21); R2(d,e,a,b,c,22); R2(c,d,e,a,b,23);
+    R2(b,c,d,e,a,24); R2(a,b,c,d,e,25); R2(e,a,b,c,d,26); R2(d,e,a,b,c,27);
+    R2(c,d,e,a,b,28); R2(b,c,d,e,a,29); R2(a,b,c,d,e,30); R2(e,a,b,c,d,31);
+    R2(d,e,a,b,c,32); R2(c,d,e,a,b,33); R2(b,c,d,e,a,34); R2(a,b,c,d,e,35);
+    R2(e,a,b,c,d,36); R2(d,e,a,b,c,37); R2(c,d,e,a,b,38); R2(b,c,d,e,a,39);
+    R3(a,b,c,d,e,40); R3(e,a,b,c,d,41); R3(d,e,a,b,c,42); R3(c,d,e,a,b,43);
+    R3(b,c,d,e,a,44); R3(a,b,c,d,e,45); R3(e,a,b,c,d,46); R3(d,e,a,b,c,47);
+    R3(c,d,e,a,b,48); R3(b,c,d,e,a,49); R3(a,b,c,d,e,50); R3(e,a,b,c,d,51);
+    R3(d,e,a,b,c,52); R3(c,d,e,a,b,53); R3(b,c,d,e,a,54); R3(a,b,c,d,e,55);
+    R3(e,a,b,c,d,56); R3(d,e,a,b,c,57); R3(c,d,e,a,b,58); R3(b,c,d,e,a,59);
+    R4(a,b,c,d,e,60); R4(e,a,b,c,d,61); R4(d,e,a,b,c,62); R4(c,d,e,a,b,63);
+    R4(b,c,d,e,a,64); R4(a,b,c,d,e,65); R4(e,a,b,c,d,66); R4(d,e,a,b,c,67);
+    R4(c,d,e,a,b,68); R4(b,c,d,e,a,69); R4(a,b,c,d,e,70); R4(e,a,b,c,d,71);
+    R4(d,e,a,b,c,72); R4(c,d,e,a,b,73); R4(b,c,d,e,a,74); R4(a,b,c,d,e,75);
+    R4(e,a,b,c,d,76); R4(d,e,a,b,c,77); R4(c,d,e,a,b,78); R4(b,c,d,e,a,79);
+    /* Add the working vars back into context.state[] */
+    state[0] += a;
+    state[1] += b;
+    state[2] += c;
+    state[3] += d;
+    state[4] += e;
+    /* Wipe variables */
+    a = b = c = d = e = 0;
+#ifdef SHA1HANDSOFF
+    memset(block, '\0', sizeof(block));
+#endif
+}
+
+
+/* SHA1Init - Initialize new context */
+
+void SHA1Init(SHA1_CTX* context)
+{
+    /* SHA1 initialization constants */
+    context->state[0] = 0x67452301;
+    context->state[1] = 0xEFCDAB89;
+    context->state[2] = 0x98BADCFE;
+    context->state[3] = 0x10325476;
+    context->state[4] = 0xC3D2E1F0;
+    context->count[0] = context->count[1] = 0;
+}
+
+
+/* Run your data through this. */
+
+void SHA1Update(SHA1_CTX* context, const uint8_t* data, size_t len)
+{
+uint32_t i;
+uint32_t j;
+
+    j = context->count[0];
+    if ((context->count[0] += len << 3) < j)
+	context->count[1]++;
+    context->count[1] += (len>>29);
+    j = (j >> 3) & 63;
+    if ((j + len) > 63) {
+        memcpy(&context->buffer[j], data, (i = 64-j));
+        SHA1Transform(context->state, context->buffer);
+        for ( ; i + 63 < len; i += 64) {
+            SHA1Transform(context->state, &data[i]);
+        }
+        j = 0;
+    }
+    else i = 0;
+    memcpy(&context->buffer[j], &data[i], len - i);
+}
+
+
+/* Add padding and return the message digest. */
+
+void SHA1Final(SHA1_CTX* context, uint8_t digest[20])
+{
+unsigned int i;
+uint8_t finalcount[8];
+uint8_t c;
+
+#if 0	/* untested "improvement" by DHR */
+    /* Convert context->count to a sequence of bytes
+     * in finalcount.  Second element first, but
+     * big-endian order within element.
+     * But we do it all backwards.
+     */
+    uint8_t *fcp = &finalcount[8];
+
+    for (i = 0; i < 2; i++)
+    {
+	uint32_t t = context->count[i];
+	int j;
+
+	for (j = 0; j < 4; t >>= 8, j++)
+	    *--fcp = (uint8_t) t
+    }
+#else
+    for (i = 0; i < 8; i++) {
+        finalcount[i] = (uint8_t)((context->count[(i >= 4 ? 0 : 1)]
+         >> ((3-(i & 3)) * 8) ) & 255);  /* Endian independent */
+    }
+#endif
+    c = 0200;
+    SHA1Update(context, &c, 1);
+    while ((context->count[0] & 504) != 448) {
+	c = 0000;
+        SHA1Update(context, &c, 1);
+    }
+    SHA1Update(context, finalcount, 8);  /* Should cause a SHA1Transform() */
+    for (i = 0; i < 20; i++) {
+        digest[i] = (uint8_t)
+         ((context->state[i>>2] >> ((3-(i & 3)) * 8) ) & 255);
+    }
+    /* Wipe variables */
+    memset(context, '\0', sizeof(*context));
+    memset(&finalcount, '\0', sizeof(finalcount));
+}
+/* ================ end of sha1.c ================ */
+
+#if 0
+#define BUFSIZE 4096
+
+int
+main(int argc, char **argv)
+{
+    SHA1_CTX ctx;
+    uint8_t hash[20], buf[BUFSIZE];
+    int i;
+
+    for(i=0;i<BUFSIZE;i++)
+        buf[i] = i;
+
+    SHA1Init(&ctx);
+    for(i=0;i<1000;i++)
+        SHA1Update(&ctx, buf, BUFSIZE);
+    SHA1Final(hash, &ctx);
+
+    printf("SHA1=");
+    for(i=0;i<20;i++)
+        printf("%02x", hash[i]);
+    printf("\n");
+    return 0;
+}
+
+#endif

--- a/src/sha1.h
+++ b/src/sha1.h
@@ -1,0 +1,22 @@
+/* public api for steve reid's public domain SHA-1 implementation */
+/* this file is in the public domain */
+#ifndef SHA1_H
+#define SHA1_H
+
+#include <stdint.h>
+#include <stdlib.h>
+
+typedef struct
+{
+    uint32_t state[5];
+    uint32_t count[2];
+    uint8_t  buffer[64];
+} SHA1_CTX;
+
+#define SHA1_DIGEST_SIZE 20
+
+void SHA1Init(SHA1_CTX* context);
+void SHA1Update(SHA1_CTX* context, const uint8_t* data, const size_t len);
+void SHA1Final(SHA1_CTX* context, uint8_t digest[SHA1_DIGEST_SIZE]);
+
+#endif /* SHA1_H */

--- a/src/sha_read.c
+++ b/src/sha_read.c
@@ -1,0 +1,29 @@
+#include "bakeware.h"
+#include "sha1.h"
+
+#include <unistd.h>
+
+void SHA1_Init(SHA1_CTX* context);
+void SHA1_Update(SHA1_CTX* context, const uint8_t* data, const size_t len);
+void SHA1_Final(SHA1_CTX* context, uint8_t digest[SHA1_DIGEST_SIZE]);
+
+static SHA1_CTX context;
+
+void sha_init()
+{
+    SHA1Init(&context);
+}
+
+ssize_t sha_read(int fd, void *buf, size_t nbytes)
+{
+    ssize_t rc = read(fd, buf, nbytes);
+    if (rc > 0)
+        SHA1Update(&context, (const uint8_t *) buf, rc);
+
+    return rc;
+}
+
+void sha_result(uint8_t *digest)
+{
+    SHA1Final(&context, digest);
+}

--- a/src/trailer.c
+++ b/src/trailer.c
@@ -12,7 +12,7 @@
 #define BW_TRAILER_V1_FLAGS           (BW_TRAILER_V1_LENGTH - 8)
 #define BW_TRAILER_V1_CONTENTS_OFFSET (BW_TRAILER_V1_LENGTH - 12)
 #define BW_TRAILER_V1_CONTENTS_LENGTH (BW_TRAILER_V1_LENGTH - 16)
-#define BW_TRAILER_V1_SHA256          (BW_TRAILER_V1_LENGTH - 48)
+#define BW_TRAILER_V1_SHA1            (BW_TRAILER_V1_LENGTH - 48)
 
 static uint32_t read_be32(const uint8_t *buffer)
 {
@@ -24,17 +24,14 @@ static uint16_t read_be16(const uint8_t *buffer)
     return (buffer[0] << 8) + buffer[1];
 }
 
-static void sha256_to_ascii(const uint8_t *input, char *output)
+static void sha1_to_ascii(const uint8_t *input, char *output)
 {
-    sprintf(output, "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
+    sprintf(output, "%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x%02x",
         input[0], input[1],input[2],input[3],
         input[4], input[5],input[6],input[7],
         input[8], input[9],input[10],input[11],
         input[12], input[13],input[14],input[15],
-        input[16], input[17],input[18],input[19],
-        input[20], input[21],input[22],input[23],
-        input[24], input[25],input[26],input[27],
-        input[28], input[29],input[30],input[31]);
+        input[16], input[17],input[18],input[19]);
 }
 
 int bw_read_trailer(int fd, struct bakeware_trailer *trailer)
@@ -62,8 +59,8 @@ int bw_read_trailer(int fd, struct bakeware_trailer *trailer)
     trailer->flags = read_be16(&buffer[BW_TRAILER_V1_FLAGS]);
     trailer->contents_offset = read_be32(&buffer[BW_TRAILER_V1_CONTENTS_OFFSET]);
     trailer->contents_length = read_be32(&buffer[BW_TRAILER_V1_CONTENTS_LENGTH]);
-    memcpy(trailer->sha256, &buffer[BW_TRAILER_V1_SHA256], sizeof(trailer->sha256));
-    sha256_to_ascii(trailer->sha256, trailer->sha256_ascii);
+    memcpy(trailer->sha1, &buffer[BW_TRAILER_V1_SHA1], sizeof(trailer->sha1));
+    sha1_to_ascii(trailer->sha1, trailer->sha1_ascii);
 
     return 0;
 }

--- a/src/unzstd.c
+++ b/src/unzstd.c
@@ -74,7 +74,7 @@ ssize_t unzstd_read(int fd, void *buf, size_t count)
             if (to_read == 0)
                 return 0;
 
-            ssize_t amount = read(fd, info.input_buffer, to_read);
+            ssize_t amount = sha_read(fd, info.input_buffer, to_read);
             if (amount <= 0) {
                 bw_fatal("Error reading %d bytes", (int) to_read);
                 return -1;


### PR DESCRIPTION
During SpawnFest, we used SHA-256 to create deterministic and unique directory names in the cache. Due to lack of time, we never validated the checksums of the archive. We also never discussed whether SHA-256 was appropriate.

This change adds verification and shortens the hash to SHA-1. The logic is that SHA-256 isn't needed and standalone SHA-1 implementations are easy-to-find in C. The bakeware archive trailer still has enough bytes reserved to return to SHA-256 if ever needed.

A side effect is that the cache directories names are a little shorter. 

NOTE: Tests are coming shortly after this PR.