### PR TITLE
Compression level

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,8 @@ Here's a quick list of features:
   release settings
 * Supports OSX and Linux (We wrote the code with Windows and the BSDs in mind,
   so support for those platforms may not be far off)
-* [Zstd compression](https://en.wikipedia.org/wiki/Zstandard) for small binaries
+* [Zstandard compression](https://en.wikipedia.org/wiki/Zstandard) for smaller
+  binaries
 * Optional support for automatic software updates (work in progress)
 * Command-line argument passing conveniences
 * Lots of examples
@@ -65,6 +66,12 @@ def release do
     ]
   ]
 end
+
+Bakeware adds the following options (these are at the same level as `:steps`
+above):
+
+* `:compression_level` - Zstandard compression level (1 to 19) where higher
+  numbers generally result in better compression, but are slower to build
 ```
 <!-- ASSEMBLE !-->
 
@@ -147,6 +154,8 @@ do:
    for files or dependencies that you might be including on accident.
 5. Make sure that compile-time dependencies are marked as `runtime: false` in
    your `mix.exs` so that they're not included
+6. Try raising the compression Zstandard compression level by setting
+  `:compression_level` in the `mix.exs` release config
 
 ### Erlang distribution
 
@@ -212,7 +221,7 @@ Offset from end | Field           | Type           | Description
  -------------- | --------------- | -------------- | -----------
 -4              | Magic           | 4 byte string  | Set to "BAKE"
 -5              | Trailer version | 8-bit integer  | Set to 1
--6              | Compression     | 8-bit integer  | 0 = No compression, 1 = Zstd
+-6              | Compression     | 8-bit integer  | 0 = No compression, 1 = Zstandard
 -8              | Flags           | 16-bit integer | Set to 0 (no flags yet)
 -12             | Contents offset | 32-bit integer | Offset of CPIO archive
 -16             | Contents length | 32-bit integer | Length of CPIO archive

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -1,6 +1,17 @@
 defmodule Bakeware.Assembler do
   @moduledoc false
-  defstruct [:compress?, :cpio, :launcher, :name, :output, :path, :release, :rel_path, :trailer]
+  defstruct [
+    :compress?,
+    :compression_level,
+    :cpio,
+    :launcher,
+    :name,
+    :output,
+    :path,
+    :release,
+    :rel_path,
+    :trailer
+  ]
 
   alias Bakeware.CPIO
 
@@ -108,6 +119,8 @@ defmodule Bakeware.Assembler do
   end
 
   defp set_compression(assembler) do
+    ##
+    # TODO: Make compression required and move this
     compress? =
       case System.find_executable("zstd") do
         nil ->
@@ -122,6 +135,16 @@ defmodule Bakeware.Assembler do
           true
       end
 
-    %{assembler | compress?: compress?}
+    compression_level = assembler.release.options[:compression_level] || 15
+
+    if compression_level not in 1..19 do
+      Mix.raise(
+        "[Bakeware] invalid zstd compression level - Must be an integer 1-19. Got: #{
+          inspect(compression_level)
+        }"
+      )
+    end
+
+    %{assembler | compression_level: compression_level, compress?: compress?}
   end
 end

--- a/lib/bakeware/cpio.ex
+++ b/lib/bakeware/cpio.ex
@@ -63,7 +63,10 @@ defmodule Bakeware.CPIO do
 
   defp maybe_compress(%{compress?: true} = assembler) do
     out = assembler.cpio <> ".zst"
-    {_, 0} = System.cmd("zstd", ["-15", assembler.cpio, "-o", out, "--rm"])
+
+    {_, 0} =
+      System.cmd("zstd", ["-#{assembler.compression_level}", assembler.cpio, "-o", out, "--rm"])
+
     File.rename(out, assembler.cpio)
   end
 


### PR DESCRIPTION
Resolves https://github.com/bake-bake-bake/bakeware/issues/85

Allows you to set the compression level for a bakeware release.

Currently looks for the `:compression_level` option key. I debated scoping that to `bakeware: [compression_level: 15]`, but ultimately left it at the root. What do you think?

Also updates the example scripts to lower compression for CI