### PR TITLE
Support Mix release commands

### DIFF
--- a/src/bakeware.h
+++ b/src/bakeware.h
@@ -109,6 +109,9 @@ struct bakeware
 
     // Application invocation
     char app_path[256 + 128];
+
+    // Mix Release command
+    char start_command[BAKEWARE_MAX_START_COMMAND_LEN + 1];
 };
 
 #endif

--- a/src/main.c
+++ b/src/main.c
@@ -33,6 +33,12 @@ static void process_arguments(int argc, char *argv[])
             bw.print_info = true;
             argv[i] = "";
             break;
+        } else if (strcmp(argv[i], "--bw-command") == 0) {
+            strncpy(bw.start_command, argv[i + 1], BAKEWARE_MAX_START_COMMAND_LEN);
+            bw.start_command[BAKEWARE_MAX_START_COMMAND_LEN] = 0;
+            argv[i] = "";
+            argv[i + 1] = "";
+            break;
         }
     }
 }
@@ -81,9 +87,15 @@ static void init_bk(int argc, char *argv[])
 
 static void run_application()
 {
+    const char *start_command;
+    if (*bw.start_command != '\0')
+        start_command = bw.start_command;
+    else
+        start_command = bw.trailer.start_command;
+
     bw_debug("Running %s...", bw.app_path);
     update_environment(bw.argc, bw.argv);
-    execl(bw.app_path, bw.app_path, bw.trailer.start_command, NULL);
+    execl(bw.app_path, bw.app_path, start_command, NULL);
     bw_fatal("Failed to start application '%s'", bw.app_path);
 }
 

--- a/test/bakeware_test.exs
+++ b/test/bakeware_test.exs
@@ -162,4 +162,16 @@ defmodule BakewareTest do
     # See the command test's mix.exs file to see that it runs "version" by default
     assert result == "command_test 0.1.0\n"
   end
+
+  @tag :tmp_dir
+  test "runs with specified mix release command", %{tmp_dir: tmp_dir} do
+    tmp_dir = fix_tmp_dir(tmp_dir)
+
+    {result, 0} =
+      System.cmd(@rel_test_binary, ["--bw-command", "version"],
+        env: [{"BAKEWARE_CACHE", Path.absname(tmp_dir)}]
+      )
+
+    assert result == "rel_test 0.1.0\n"
+  end
 end


### PR DESCRIPTION
Resolves #91

Allows one to specify a mix release command to use with `--mix-{CMD}`

This is currently producing a Seg fault, but at least getting it up for someone better at C than me to look at why. (Or I will revisit when time allows)