### PR TITLE
Support changing the release script start command

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ above):
 
 * `:compression_level` - Zstandard compression level (1 to 19) where higher
   numbers generally result in better compression, but are slower to build
+* `:start_command` - The start script command to run when invoked. This defaults
+  to `"start"`, but can be changed to `"start_iex"`, for example, if you want a
+  prompt.
 ```
 <!-- ASSEMBLE !-->
 

--- a/examples/iex_prompt/lib/iex_prompt.ex
+++ b/examples/iex_prompt/lib/iex_prompt.ex
@@ -2,14 +2,9 @@ defmodule IExPrompt do
   use Bakeware.Script
 
   def main(_) do
-    pid = IEx.start()
-    Process.group_leader(self(), pid)
-    Process.monitor(pid)
-
+    # Wait forever
     receive do
-      _ ->
-        IO.warn("IEx Died")
-        :ok
+      _ -> :ok
     end
   end
 end

--- a/examples/iex_prompt/mix.exs
+++ b/examples/iex_prompt/mix.exs
@@ -36,7 +36,8 @@ defmodule IExPrompt.MixProject do
       cookie: "#{@app}_cookie",
       quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
-      strip_beams: Mix.env() == :prod
+      strip_beams: Mix.env() == :prod,
+      start_command: "start_iex"
     ]
   end
 end

--- a/examples/iex_prompt/mix.exs
+++ b/examples/iex_prompt/mix.exs
@@ -36,7 +36,7 @@ defmodule IExPrompt.MixProject do
       cookie: "#{@app}_cookie",
       quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
-      strip_beams: Mix.env() == :prod,
+      strip_beams: [keep: ["Docs"]],
       start_command: "start_iex"
     ]
   end

--- a/src/bakeware.h
+++ b/src/bakeware.h
@@ -34,6 +34,8 @@ void bw_cache_directory(char *path, size_t len);
 int bw_set_environment(const char *key, int index, const char *value);
 void bw_bin_to_hex(const uint8_t *input, char *output, size_t input_len);
 
+#define BAKEWARE_MAX_START_COMMAND_LEN 12
+
 // Trailer parsing
 struct bakeware_trailer
 {
@@ -46,6 +48,8 @@ struct bakeware_trailer
 
     uint8_t sha1[20];
     char sha1_ascii[41];
+
+    char start_command[BAKEWARE_MAX_START_COMMAND_LEN + 1];
 };
 
 #define BAKEWARE_COMPRESSION_NONE 0

--- a/src/main.c
+++ b/src/main.c
@@ -83,7 +83,7 @@ static void run_application()
 {
     bw_debug("Running %s...", bw.app_path);
     update_environment(bw.argc, bw.argv);
-    execl(bw.app_path, bw.app_path, NULL);
+    execl(bw.app_path, bw.app_path, bw.trailer.start_command, NULL);
     bw_fatal("Failed to start application '%s'", bw.app_path);
 }
 

--- a/src/trailer.c
+++ b/src/trailer.c
@@ -12,6 +12,7 @@
 #define BW_TRAILER_V1_FLAGS           (BW_TRAILER_V1_LENGTH - 8)
 #define BW_TRAILER_V1_CONTENTS_OFFSET (BW_TRAILER_V1_LENGTH - 12)
 #define BW_TRAILER_V1_CONTENTS_LENGTH (BW_TRAILER_V1_LENGTH - 16)
+#define BW_TRAILER_V1_START_COMMAND   (BW_TRAILER_V1_LENGTH - 28)
 #define BW_TRAILER_V1_SHA1            (BW_TRAILER_V1_LENGTH - 48)
 
 static uint32_t read_be32(const uint8_t *buffer)
@@ -56,7 +57,8 @@ int bw_read_trailer(int fd, struct bakeware_trailer *trailer)
     trailer->contents_length = read_be32(&buffer[BW_TRAILER_V1_CONTENTS_LENGTH]);
     memcpy(trailer->sha1, &buffer[BW_TRAILER_V1_SHA1], sizeof(trailer->sha1));
     sha1_to_ascii(trailer->sha1, trailer->sha1_ascii);
+    memcpy(trailer->start_command, &buffer[BW_TRAILER_V1_START_COMMAND], BAKEWARE_MAX_START_COMMAND_LEN);
+    trailer->start_command[BAKEWARE_MAX_START_COMMAND_LEN] = 0;
 
     return 0;
 }
-

--- a/test/fixtures/command_test/.gitignore
+++ b/test/fixtures/command_test/.gitignore
@@ -1,0 +1,28 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# Ignore .fetch files in case you like to edit your project deps locally.
+/.fetch
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+command_test-*.tar
+
+
+# Temporary files for e.g. tests
+/tmp
+/mix.lock

--- a/test/fixtures/command_test/lib/rel_test/application.ex
+++ b/test/fixtures/command_test/lib/rel_test/application.ex
@@ -1,0 +1,13 @@
+defmodule CommandTest.Application do
+  # See https://hexdocs.pm/elixir/Application.html
+  # for more information on OTP Applications
+  @moduledoc false
+
+  use Application
+
+  @impl true
+  def start(_type, _args) do
+    IO.puts("Hello, CommandTest!")
+    :erlang.halt()
+  end
+end

--- a/test/fixtures/command_test/mix.exs
+++ b/test/fixtures/command_test/mix.exs
@@ -1,0 +1,44 @@
+defmodule CommandTest.MixProject do
+  use Mix.Project
+
+  @app :command_test
+
+  def project do
+    [
+      app: @app,
+      version: "0.1.0",
+      elixir: "~> 1.10",
+      start_permanent: Mix.env() == :prod,
+      deps: deps(),
+      releases: [{@app, release()}],
+      preferred_cli_env: [release: :prod]
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger],
+      mod: {CommandTest.Application, []}
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:bakeware, path: "../../..", runtime: false}
+    ]
+  end
+
+  defp release do
+    [
+      overwrite: true,
+      cookie: "#{@app}_cookie",
+      quiet: true,
+      steps: [:assemble, &Bakeware.assemble/1],
+      strip_beams: Mix.env() == :prod,
+      compression_level: 1,
+      start_command: "version"
+    ]
+  end
+end

--- a/test/fixtures/command_test/rel/env.bat.eex
+++ b/test/fixtures/command_test/rel/env.bat.eex
@@ -1,0 +1,3 @@
+@echo off
+rem Disable Erlang distribution
+set RELEASE_DISTRIBUTION=none

--- a/test/fixtures/command_test/rel/env.sh.eex
+++ b/test/fixtures/command_test/rel/env.sh.eex
@@ -1,0 +1,4 @@
+#!/bin/sh
+
+# Disable Erlang distribution
+export RELEASE_DISTRIBUTION=none

--- a/test/fixtures/command_test/rel/vm.args.eex
+++ b/test/fixtures/command_test/rel/vm.args.eex
@@ -1,0 +1,11 @@
+## Customize flags given to the VM: http://erlang.org/doc/man/erl.html
+## -mode/-name/-sname/-setcookie are configured via env vars, do not set them here
+
+## Number of dirty schedulers doing IO work (file, sockets, and others)
+##+SDio 5
+
+## Increase number of concurrent ports/sockets
+##+Q 65536
+
+## Tweak GC to run more often
+##-env ERL_FULLSWEEP_AFTER 10


### PR DESCRIPTION
This extracts the start command support in the trailer from PR #92, adds a unit
test to verify that it works, and updates the iex_prompt example to use it.

The iex_prompt example now supports the arrow keys, history, etc., that you
expect to have at the prompt. This avoids the needs to use `rlwrap` to add this
functionality back in. I also updated the release spec to keep the help docs
since those are nice to have and don't bloat the image all that much.
