### PR TITLE
Scope bakeware release options to :bakeware

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,16 +66,29 @@ def release do
     ]
   ]
 end
+```
 
-Bakeware adds the following options (these are at the same level as `:steps`
-above):
+Bakeware adds the following options in the release scoped to `:bakeware` key:
 
 * `:compression_level` - Zstandard compression level (1 to 19) where higher
   numbers generally result in better compression, but are slower to build
 * `:start_command` - The start script command to run when invoked. This defaults
   to `"start"`, but can be changed to `"start_iex"`, for example, if you want a
   prompt.
+
+```elixir
+def release do
+  [
+    demo: [
+      bakeware: [
+        compression_level: 1,
+        start_command: "daemon"
+      ]
+    ]
+  ]
+end
 ```
+
 <!-- ASSEMBLE !-->
 
 ### Scripting

--- a/examples/iex_prompt/mix.exs
+++ b/examples/iex_prompt/mix.exs
@@ -37,7 +37,7 @@ defmodule IExPrompt.MixProject do
       quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
       strip_beams: [keep: ["Docs"]],
-      start_command: "start_iex"
+      bakeware: [start_command: "start_iex"]
     ]
   end
 end

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -155,6 +155,8 @@ defmodule Bakeware.Assembler do
           true
       end
 
+    check_invalid_option!(assembler.release, :compression_level)
+
     compression_level = assembler.release.options[:bakeware][:compression_level] || 15
 
     if compression_level not in 1..19 do
@@ -169,6 +171,7 @@ defmodule Bakeware.Assembler do
   end
 
   defp set_start_command(assembler) do
+    check_invalid_option!(assembler.release, :start_command)
     command = assembler.release.options[:bakeware][:start_command] || "start"
     cmd_len = byte_size(command)
 
@@ -183,5 +186,26 @@ defmodule Bakeware.Assembler do
     end
 
     %{assembler | start_command: command}
+  end
+
+  defp check_invalid_option!(release, option) do
+    if value = release.options[option] do
+      Mix.raise("""
+      [Bakeware] setting :#{option} in the release options outside of the :bakeware key is no longer supported.
+
+      Please adjust your release options in mix.exs to continue:
+
+        def release do
+          [
+            ...
+            steps: [&Bakeware.assemble/1, :assemble],
+            bakeware: [#{option}: #{inspect(value)}]
+            ...
+          ]
+        end
+      """)
+    end
+
+    :ok
   end
 end

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -155,7 +155,7 @@ defmodule Bakeware.Assembler do
           true
       end
 
-    compression_level = assembler.release.options[:compression_level] || 15
+    compression_level = assembler.release.options[:bakeware][:compression_level] || 15
 
     if compression_level not in 1..19 do
       Mix.raise(
@@ -169,7 +169,7 @@ defmodule Bakeware.Assembler do
   end
 
   defp set_start_command(assembler) do
-    command = assembler.release.options[:start_command] || "start"
+    command = assembler.release.options[:bakeware][:start_command] || "start"
     cmd_len = byte_size(command)
 
     if cmd_len > 12 do

--- a/test/fixtures/command_test/mix.exs
+++ b/test/fixtures/command_test/mix.exs
@@ -37,8 +37,10 @@ defmodule CommandTest.MixProject do
       quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
       strip_beams: Mix.env() == :prod,
-      compression_level: 1,
-      start_command: "version"
+      bakeware: [
+        compression_level: 1,
+        start_command: "version"
+      ]
     ]
   end
 end

--- a/test/fixtures/rel_test/mix.exs
+++ b/test/fixtures/rel_test/mix.exs
@@ -37,7 +37,7 @@ defmodule RelTest.MixProject do
       quiet: true,
       steps: [:assemble, &Bakeware.assemble/1],
       strip_beams: Mix.env() == :prod,
-      compression_level: 1
+      bakeware: [compression_level: 1]
     ]
   end
 end


### PR DESCRIPTION
I've debated this on and off and now I'm more on the side of avoiding clashing options with Mix releases. So this scopes all the release options to a `:bakeware` key in the release to allow us to add/remove options without having to worry about what might be done with Mix releases