### PR TITLE
Windows Support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -24,6 +24,10 @@ BUILD  = $(MIX_APP_PATH)/obj
 CFLAGS ?= -O2 -Wall -Wextra -Wno-unused-parameter -pedantic
 CFLAGS += -D_GNU_SOURCE
 LDFLAGS ?=
+OUTPUT_FLAGS = -o
+ifeq ($(OS),Windows_NT)
+	OUTPUT_FLAGS = -pipe -Wl,-o
+endif
 
 BAKEWARE_OBJECTS = \
 	$(BUILD)/cache.o \
@@ -58,7 +62,7 @@ $(BUILD)/%.o: src/%.c
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
-	$(CC) $^ $(LDFLAGS) -o $@
+	$(CC) $^ $(LDFLAGS) $(OUTPUT_FLAGS)$@
 	strip $@
 
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):

--- a/README.md
+++ b/README.md
@@ -191,6 +191,16 @@ mix release
 cp _build/prod/rel/bakeware/myproject .
 ```
 
+### Building on Windows
+
+Bakeware is tested to work in mingw environment on Windows 8 and 10. In order to setup the environment follow these steps:
+
+* Install [`chocolatey`](https://chocolatey.org/install)
+* Install elixir, zstandard, make, and mingw using chocolatey: `choco install -y elixir zstandard make mingw`
+* We need to change the default `nmake` used by `elixir_make` for Windows to `make` that we just installed: `export MAKE=make`
+* Export the CC variable as well: `export CC=gcc`
+* Now everything is set and the final standalone executable should get built with`mix release`
+
 ## Reference material
 
 ### Command-line arguments

--- a/src/bakeware.h
+++ b/src/bakeware.h
@@ -114,4 +114,12 @@ struct bakeware
     char start_command[BAKEWARE_MAX_START_COMMAND_LEN + 1];
 };
 
+#if (defined(_WIN32) || defined(_WIN64))
+#define mkdir(A, B) mkdir(A)
+#endif
+
+#if (!defined(_WIN32) && !defined(_WIN64))
+#define O_BINARY 0
+#endif
+
 #endif

--- a/src/cache.c
+++ b/src/cache.c
@@ -1,11 +1,11 @@
-#include "bakeware.h"
-
 #include <errno.h>
 #include <stdio.h>
 #include <string.h>
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include "bakeware.h"
 
 void cache_init(struct bakeware *bw)
 {
@@ -57,9 +57,13 @@ int cache_validate(struct bakeware *bw)
     // Expand to a temporary directory
     char tmp_dir_template[256+64];
     snprintf(tmp_dir_template, sizeof(tmp_dir_template), "%s/XXXXXX", bw->cache_dir_tmp);
-    char *tmp_dir = mkdtemp(tmp_dir_template);
+    char *tmp_dir = mktemp(tmp_dir_template);
     if (tmp_dir == NULL) {
         bw_warn("Can't create expand archive under '%s'", bw->cache_dir_base);
+        return -1;
+    }
+    if (mkdir(tmp_dir, 0755) < 0 && errno != EEXIST) {
+        bw_warn("Error creating directory %s??", tmp_dir);
         return -1;
     }
 

--- a/src/cpio.c
+++ b/src/cpio.c
@@ -1,9 +1,10 @@
-#include "bakeware.h"
 #include <sys/stat.h>
 #include <sys/types.h>
 #include <stdio.h>
 #include <string.h>
 #include <errno.h>
+
+#include "bakeware.h"
 
 #define CPIO_MAGIC 0x070701 // CPIO newc format
 #define CPIO_LAST  "TRAILER!!!"

--- a/src/main.c
+++ b/src/main.c
@@ -1,4 +1,3 @@
-#include "bakeware.h"
 #include <stdbool.h>
 #include <stdio.h>
 #include <string.h>
@@ -8,6 +7,8 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 #include <unistd.h>
+
+#include "bakeware.h"
 
 struct bakeware bw;
 
@@ -105,7 +106,7 @@ int main(int argc, char *argv[])
 
     bw_debug("starting '%s' (cachedir=%s)...", bw.path, bw.cache_dir_base);
 
-    bw.fd = open(bw.path, O_RDONLY);
+    bw.fd = open(bw.path, O_RDONLY | O_BINARY);
     if (bw.fd < 0)
         bw_fatal("Can't open '%s'", bw.path);
 

--- a/src/rm_fr.c
+++ b/src/rm_fr.c
@@ -1,9 +1,9 @@
-#include "bakeware.h"
-
 #include <ftw.h>
 #include <stdio.h>
 #include <unistd.h>
 #include <limits.h>
+
+#include "bakeware.h"
 
 // OPEN_MAX isn't defined on some systems. Note that many nftw man pages say
 // that the max open file handles parameter is ignored, but it's definitely not

--- a/src/sha1.c
+++ b/src/sha1.c
@@ -42,7 +42,7 @@ A million repetitions of "a"
 
 #if defined(vax) || defined(ns32000) || defined(sun386) || defined(__i386__) || \
     defined(MIPSEL) || defined(_MIPSEL) || defined(BIT_ZERO_ON_RIGHT) || \
-    defined(__alpha__) || defined(__alpha)
+    defined(__alpha__) || defined(__alpha) || defined(_WIN32) || defined(_WIN64)
 #define BYTE_ORDER	LITTLE_ENDIAN
 #endif
 

--- a/src/sha_read.c
+++ b/src/sha_read.c
@@ -1,7 +1,7 @@
+#include <unistd.h>
+
 #include "bakeware.h"
 #include "sha1.h"
-
-#include <unistd.h>
 
 void SHA1_Init(SHA1_CTX* context);
 void SHA1_Update(SHA1_CTX* context, const uint8_t* data, const size_t len);

--- a/src/trailer.c
+++ b/src/trailer.c
@@ -1,9 +1,9 @@
-#include "bakeware.h"
-
 #include <stdio.h>
 #include <string.h>
 #include <sys/types.h>
 #include <unistd.h>
+
+#include "bakeware.h"
 
 #define BW_TRAILER_V1_LENGTH          48
 #define BW_TRAILER_V1_MAGIC           (BW_TRAILER_V1_LENGTH - 4)

--- a/src/unzstd.c
+++ b/src/unzstd.c
@@ -1,7 +1,8 @@
-#include "bakeware.h"
-#include "zstd/lib/zstd.h"
 #include <unistd.h>
 #include <string.h>
+
+#include "bakeware.h"
+#include "zstd/lib/zstd.h"
 
 struct unzstd_info
 {

--- a/src/utils.c
+++ b/src/utils.c
@@ -105,7 +105,7 @@ void bw_cache_directory(char *path, size_t len)
         return;
     } else {
 #if defined (_WIN64) || defined(_WIN32)
-#error Implement
+    snprintf(path, len, "%s\\AppData\\Local\\Bakeware", getenv("userprofile"));
 #elif __APPLE__
     snprintf(path, len, "%s//Library/Caches/Bakeware", getenv("HOME"));
 #elif (__linux || __unix || __posix)


### PR DESCRIPTION
I have got this working with mingw on windows. My environment has elixir and mingw installed via chocolatey.

Changes:
+ Windows needs `O_BINARY` flag for reading cpio which is absent in unix, otherwise it encounters unexpected EOF.
+ mkdtemp(absent in windows) replaced with mktemp and mkdir.
+ mkdir takes only 1 argument in mingw and msvc header files where as posix mkdir takes 2 arguments, so added a macro to replace the call having 2 arguments with 1.
+ gcc `-pipe -Wl,-o` to remove automatically added `.exe` extension in intermediate launcher binary.
+ Add `.exe` to the final binary in case of windows.

No luck with MSVC due to non-availability of a drop-in replacement for unistd.h in windows.

Fixes bake-bake-bake/bakeware#37