### PR TITLE
Improve/expand Windows compatibility

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -66,7 +66,12 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 	strip $@
 
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
-	mkdir -p $@
+	ifeq ($(OS),Windows_NT)
+		mkdir $@
+	else
+		mkdir -p $@
+	endif
+	
 
 clean:
 	$(RM) $(PREFIX)/launcher \

--- a/Makefile
+++ b/Makefile
@@ -65,13 +65,13 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 	$(CC) $^ $(LDFLAGS) $(OUTPUT_FLAGS)$@
 	strip $@
 
+ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
-	ifeq ($(OS),Windows_NT)
-		mkdir $@
-	else
-		mkdir -p $@
-	endif
-	
+	mkdir "$@"
+else
+$(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
+	mkdir -p $@
+endif
 
 clean:
 	$(RM) $(PREFIX)/launcher \

--- a/README.md
+++ b/README.md
@@ -143,6 +143,7 @@ do:
 1. Make sure `zstd` is installed to enable compression during assembly:
   * **MacOS**: `brew install zstd`
   * **Ubuntu**: `apt-get install zstd`
+  * **Windows**: `choco install zstandard`
 2. Build using `MIX_ENV=prod`. The default is `MIX_ENV=dev`, so be sure that the
    environment variable is set.
 3. Run `rm -fr _build` and then `mix release`. During development cruft builds

--- a/README.md
+++ b/README.md
@@ -211,9 +211,35 @@ Bakeware is tested to work in mingw environment on Windows 8 and 10. In order to
 
 * Install [`chocolatey`](https://chocolatey.org/install)
 * Install elixir, zstandard, make, and mingw using chocolatey: `choco install -y elixir zstandard make mingw`
-* We need to change the default `nmake` used by `elixir_make` for Windows to `make` that we just installed: `export MAKE=make`
-* Export the CC variable as well: `export CC=gcc`
-* Now everything is set and the final standalone executable should get built with`mix release`
+* Change the default `MAKE` environment variable used by `elixir_make` from `nmake` to `make` (set it permanently to get rid of the errors in VSCode)
+* Set the CC environment variable
+* Build the release
+
+#### PowerShell
+
+```powershell
+$env:MAKE="make"
+$env:CC="gcc"
+mix release
+```
+
+#### Command Prompt
+
+```
+set MAKE=make
+set CC=gcc
+mix release
+```
+
+#### MinGW
+
+Note: after building the release in MinGW, you need to switch back to PowerShell/CMD to run the application
+
+```bash
+export MAKE=make
+export CC=gcc
+mix release
+```
 
 ## Reference material
 

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -160,9 +160,17 @@ defmodule Bakeware.Assembler do
 
   defp concat_files(assembler) do
     _ =
-      :os.cmd(
-        'cat #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
-      )
+      case :os.type() do
+        {:win32, :nt} ->
+          :os.cmd(
+            'type #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
+          )
+
+        _ ->
+          :os.cmd(
+            'cat #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
+          )
+      end
 
     File.chmod!(assembler.output, 0o755)
     assembler


### PR DESCRIPTION
This PR allows the user to run commands from PowerShell and cmd.exe, in addition to MinGW, which is the current requirement. The readme has also been expanded for Windows.