### PR TITLE
Quick fixes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -3,14 +3,14 @@ version: 2.1
 parameters:
   elixir:
     type: string
-    default: 1.11.3
+    default: "1.12.3"
   erlang:
     type: string
-    default: 23.2.4
+    default: "24.1"
 
 example_requires: &example_requires
   requires:
-    - elixir-1.11.3-otp-23.2.4
+    # - elixir-1.12.3-otp-24.1
 
 commands:
   background_execute:
@@ -178,7 +178,7 @@ commands:
 executors:
   alpine: &alpine
     docker:
-      - image: hexpm/elixir:<< pipeline.parameters.elixir >>-erlang-<< pipeline.parameters.erlang >>-alpine-3.13.1
+      - image: hexpm/elixir:<< pipeline.parameters.elixir >>-erlang-<< pipeline.parameters.erlang >>-alpine-3.14.0
     environment:
       LC_ALL: C.UTF-8
       SUDO: true
@@ -189,7 +189,7 @@ executors:
     working_directory: ~/repo
   ubuntu: &ubuntu
     docker:
-      - image: hexpm/elixir:1.11.3-erlang-23.2.4-ubuntu-groovy-20201022.1
+      - image: hexpm/elixir:1.12.3-erlang-24.1-ubuntu-groovy-20210325
     environment:
       LC_ALL: C.UTF-8
       SUDO: true
@@ -298,7 +298,7 @@ jobs:
                 steps:
                   - run:
                       name: Install node
-                      command: apk add nodejs nodejs-npm
+                      command: apk add nodejs npm
             - when:
                 condition:
                   equal: [ubuntu, << parameters.os >>]
@@ -322,16 +322,8 @@ jobs:
 workflows:
   build_test:
     jobs:
-      - build:
-          name: elixir-<<matrix.elixir>>-otp-<<matrix.erlang>>
-          matrix:
-            parameters:
-              os: [alpine]
-              elixir: [1.10.4, 1.11.3]
-              erlang: [23.2.4]
-
       - test_script:
-          <<: *example_requires
+          # <<: *example_requires
           name: test simple_app <<matrix.os>>
           example: simple_app
           matrix:
@@ -340,16 +332,16 @@ workflows:
               os: [mac, alpine, ubuntu]
 
       - test_script:
-          <<: *example_requires
+          # <<: *example_requires
           name: test simple_script <<matrix.os>>
           matrix:
             parameters:
-              example: [simple_app]
+              example: [simple_script]
               args: [howdy! --upcase]
               os: [mac, alpine, ubuntu]
 
       - test_script:
-          <<: *example_requires
+          # <<: *example_requires
           name: test nif_script <<matrix.os>>
           matrix:
             parameters:
@@ -358,21 +350,21 @@ workflows:
               os: [alpine, mac, ubuntu]
 
       - test_iex:
-          <<: *example_requires
+          # <<: *example_requires
           name: test iex_prompt <<matrix.os>>
           matrix:
             parameters:
               os: [alpine, mac, ubuntu]
 
       - test_scenic:
-          <<: *example_requires
+          # <<: *example_requires
           name: test scenic_app <<matrix.os>>
           matrix:
             parameters:
               os: [alpine, ubuntu]
 
       - test_phoenix:
-          <<: *example_requires
+          # <<: *example_requires
           name: test phoenix_app <<matrix.os>>
           matrix:
             parameters:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,6 +92,7 @@ jobs:
         env:
           MAKE: make
           CC: gcc
+        shell: cmd
         run: |
           echo "$PATH"
           mix local.hex --force

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -12,8 +12,11 @@ jobs:
 
     strategy:
       matrix:
-        elixir_version: ['1.10.3', '1.11.3']
-        otp_version: ['23.3.1']
+        elixir_version: ['1.10.4', '1.11.4', '1.12.3']
+        otp_version: ['23.3.4.7', '24.1']
+        exclude:
+          - elixir_version: '1.10.4'
+            otp_version: '24.1'
 
     steps:
       - name: Checkout
@@ -39,7 +42,7 @@ jobs:
       - run: MIX_ENV=test mix compile --warnings-as-errors
       - run: mix test
       - name: Extra checks
-        if: ${{ contains(matrix.elixir_version, '1.11') }}
+        if: ${{ contains(matrix.elixir_version, '1.12') }}
         run: |
           mix format --check-formatted
           mix dialyzer --halt-exit-status
@@ -96,4 +99,3 @@ jobs:
           mix deps.get
           mix compile --warnings-as-errors
           mix test
-

--- a/lib/bakeware.ex
+++ b/lib/bakeware.ex
@@ -2,12 +2,7 @@ defmodule Bakeware do
   @doc """
   Assembler function to be used as a Mix release step
 
-  #{
-    File.read!("README.md")
-    |> String.split(~r/<!-- ASSEMBLE !-->/)
-    |> Enum.drop(1)
-    |> hd()
-  }
+  #{File.read!("README.md") |> String.split(~r/<!-- ASSEMBLE !-->/) |> Enum.drop(1) |> hd()}
   """
   defdelegate assemble(release), to: Bakeware.Assembler
 end

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -199,9 +199,7 @@ defmodule Bakeware.Assembler do
 
     if compression_level not in 1..19 do
       Mix.raise(
-        "[Bakeware] invalid zstd compression level - Must be an integer 1-19. Got: #{
-          inspect(compression_level)
-        }"
+        "[Bakeware] invalid zstd compression level - Must be an integer 1-19. Got: #{inspect(compression_level)}"
       )
     end
 

--- a/lib/bakeware/script.ex
+++ b/lib/bakeware/script.ex
@@ -2,12 +2,7 @@ defmodule Bakeware.Script do
   @moduledoc """
   Helper to generate a script that takes command-line arguments
 
-  #{
-    File.read!("README.md")
-    |> String.split(~r/<!-- SCRIPT !-->/)
-    |> Enum.drop(1)
-    |> hd()
-  }
+  #{File.read!("README.md") |> String.split(~r/<!-- SCRIPT !-->/) |> Enum.drop(1) |> hd()}
   """
 
   @type args :: [String.t()]
@@ -42,9 +37,7 @@ defmodule Bakeware.Script do
       catch
         error, reason ->
           IO.warn(
-            "Caught exception in #{__MODULE__}.main/1: #{inspect(error)} => #{
-              inspect(reason, pretty: true)
-            }",
+            "Caught exception in #{__MODULE__}.main/1: #{inspect(error)} => #{inspect(reason, pretty: true)}",
             __STACKTRACE__
           )
 


### PR DESCRIPTION
* bump workflow OTP and Elixir versions
* fix formatting
* Use CircleCI only for example testing
  * Most of the CI has been moved to Github Workflow. However, example
    testing still occurs in CircleCI. This removes the need to do the
    typical build process there and instead only compiles examples. It
    attempts the simplest example compile first and then will try all the
    rest in order to reduce overloading MacOS and other compute/build times