### PR TITLE
allow for spaces in paths for windows

### DIFF
--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -118,7 +118,7 @@ defmodule Bakeware.Assembler do
     @echo off
     setlocal enabledelayedexpansion
 
-    set ROOT=%~dp0
+    set ROOT="%~dp0"
     %ROOT%/#{start_script_path} %1
     """
 

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -159,14 +159,23 @@ defmodule Bakeware.Assembler do
   end
 
   defp concat_files(assembler) do
-    _ =
-      :os.cmd(
-        'cat #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
-      )
+    case :os.type() do
+      {:win32, :nt} ->
+        :os.cmd(
+          'type "#{win_path(assembler.launcher)}" "#{win_path(assembler.cpio)}" "#{win_path(assembler.trailer)}" > "#{win_path(assembler.output)}"'
+        )
+
+      _ ->
+        :os.cmd(
+          'cat #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
+        )
+    end
 
     File.chmod!(assembler.output, 0o755)
     assembler
   end
+
+  defp win_path(path), do: String.replace(path, "/", "\\")
 
   defp set_compression(assembler) do
     ##

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -160,17 +160,9 @@ defmodule Bakeware.Assembler do
 
   defp concat_files(assembler) do
     _ =
-      case :os.type() do
-        {:win32, :nt} ->
-          :os.cmd(
-            'type #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
-          )
-
-        _ ->
-          :os.cmd(
-            'cat #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
-          )
-      end
+      :os.cmd(
+        'cat #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
+      )
 
     File.chmod!(assembler.output, 0o755)
     assembler

--- a/lib/bakeware/assembler.ex
+++ b/lib/bakeware/assembler.ex
@@ -159,17 +159,18 @@ defmodule Bakeware.Assembler do
   end
 
   defp concat_files(assembler) do
-    case :os.type() do
-      {:win32, :nt} ->
-        :os.cmd(
-          'type "#{win_path(assembler.launcher)}" "#{win_path(assembler.cpio)}" "#{win_path(assembler.trailer)}" > "#{win_path(assembler.output)}"'
-        )
+    _ =
+      case :os.type() do
+        {:win32, :nt} ->
+          :os.cmd(
+            'type "#{win_path(assembler.launcher)}" "#{win_path(assembler.cpio)}" "#{win_path(assembler.trailer)}" > "#{win_path(assembler.output)}"'
+          )
 
-      _ ->
-        :os.cmd(
-          'cat #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
-        )
-    end
+        _ ->
+          :os.cmd(
+            'cat #{assembler.launcher} #{assembler.cpio} #{assembler.trailer} > #{assembler.output}'
+          )
+      end
 
     File.chmod!(assembler.output, 0o755)
     assembler


### PR DESCRIPTION
fixes #118
`type` command fails silently, resulting in an empty executable