### PR TITLE
initial for loop declarations and reduce Makefile prints

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -60,9 +60,11 @@ ZSTD_BUILD_DIRS = $(BUILD)/zstd/lib/decompress $(BUILD)/zstd/lib/common
 all: $(BUILD) $(PREFIX) $(ZSTD_BUILD_DIRS) $(PREFIX)/launcher
 
 $(BUILD)/%.o: src/%.c
+	@echo " CC $(notdir $@)"
 	$(CC) -c $(CFLAGS) -o $@ $<
 
 $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
+	@echo " LD $(notdir $@)"
 	$(CC) $^ $(LDFLAGS) $(OUTPUT_FLAGS)$@
 	strip $@
 
@@ -80,3 +82,5 @@ clean:
 
 .PHONY: all clean calling_from_make
 
+# Don't echo commands unless the caller exports "V=1"
+${V}.SILENT:

--- a/src/main.c
+++ b/src/main.c
@@ -14,7 +14,9 @@ struct bakeware bw;
 
 static void process_arguments(int argc, char *argv[])
 {
-    for (int i = 1; i < argc; i++) {
+    int i;
+
+    for (i = 1; i < argc; i++) {
         if (strcmp(argv[i], "--") == 0) {
             argv[i] = "";
             break;
@@ -49,7 +51,9 @@ static void update_environment(int argc, char *argv[])
     bw_set_environment("BAKEWARE_EXECUTABLE", -1, bw.path);
 
     int arg_index = 0;
-    for (int i = 1; i < argc; i++) {
+    int i;
+
+    for (i = 1; i < argc; i++) {
         const char *arg = argv[i];
 
         if (*arg == '\0')


### PR DESCRIPTION
Fixes #122 

* Use initial 'for' loop delcarations for systems without C99 mode set
* reduce prints in the Makefile