### PR TITLE
Fix mkdir

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,3 @@ erl_crash.dump
 
 # Ignore package tarball (built via "mix hex.build").
 bakeware-*.tar
-
-# Ignore tmp test files
-/tmp

--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,5 @@ erl_crash.dump
 # Ignore package tarball (built via "mix hex.build").
 bakeware-*.tar
 
+# Ignore tmp test files
+/tmp

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
-	mkdir -p "$@"
+	mkdir "$@"
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 #	mkdir "$@"
-	New-Item -Path "$@" -ItemType Directory -Force
+	md "$@" -Force
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 #	mkdir "$@"
-	md "$@" -Force
+	mkdir "$@" -Force -ErrorAction SilentlyContinue
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 #	mkdir "$@"
-	New-Item -Path "$@" -ItemType Directory
+	New-Item -Path "$@" -ItemType "directory" -Force -Confirm
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,7 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
-	mkdir "$@"
+	mkdir -p "$@"
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 #	mkdir "$@"
-	mkdir "$@" -Force -ErrorAction SilentlyContinue
+	if not exist "$@" mkdir "$@" /v
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,6 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
-#	mkdir "$@"
 	if not exist "$@" mkdir "$@"
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 #	mkdir "$@"
-	if not exist "$@" mkdir "$@" /v
+	if not exist "$@" mkdir "$@"
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -68,7 +68,8 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
-	mkdir "$@"
+#	mkdir "$@"
+	New-Item -Path "$@" -ItemType Directory
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 	mkdir -p $@

--- a/Makefile
+++ b/Makefile
@@ -69,7 +69,7 @@ $(PREFIX)/launcher: $(BAKEWARE_OBJECTS) $(ZSTD_OBJECTS)
 ifeq ($(OS),Windows_NT)
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 #	mkdir "$@"
-	New-Item -Path "$@" -ItemType "directory" -Force -Confirm
+	New-Item -Path "$@" -ItemType Directory -Force
 else
 $(PREFIX) $(BUILD) $(ZSTD_BUILD_DIRS):
 	mkdir -p $@


### PR DESCRIPTION
This is the follow up of my research on this ticket: https://github.com/bake-bake-bake/bakeware/issues/127
After smashing my head against a wall for several days, I think  I finally figured it out. 
The command was failing because of how cmd `mkdir` behaves, in that, it behaves different from the one in poewrshell. 

By changing that 1 line of code to only create folders if they don't exist already, I was able to fix the issue while still mantaining backwards compatibility, which was one of my requirements. 

You can see a MWE project using my forked branch of bakeware here:

- https://github.com/Fl4m3Ph03n1x/bake_test

Please let me know what you think, and merge when convenient. 