### PR TITLE
fix binread eof

### DIFF
--- a/lib/bakeware/cpio.ex
+++ b/lib/bakeware/cpio.ex
@@ -94,7 +94,10 @@ defmodule Bakeware.CPIO do
     # Read the file and append to CPIO
     {:ok, :ok} =
       File.open(file.path, [:read], fn fd ->
-        IO.binwrite(cpio_fd, IO.binread(fd, read_arg))
+        case IO.binread(fd, read_arg) do
+          :eof -> IO.binwrite(cpio_fd, "")
+          bin -> IO.binwrite(cpio_fd, bin)
+        end
       end)
   end
 


### PR DESCRIPTION
I am not sure why `:all` was removed in elixir 1.13 but `:eof` breaks beh on empty files by returning atom `:eof` this makes the subsequent `binwrite` fail.